### PR TITLE
Add fast processor delays

### DIFF
--- a/HX711.cpp
+++ b/HX711.cpp
@@ -20,10 +20,11 @@ HX711::~HX711()
 }
 
 
-void HX711::begin(uint8_t dataPin, uint8_t clockPin)
+void HX711::begin(uint8_t dataPin, uint8_t clockPin, bool fastProcessor )
 {
   _dataPin  = dataPin;
   _clockPin = clockPin;
+	_fast_processor = fastProcessor; 
 
   pinMode(_dataPin, INPUT);
   pinMode(_clockPin, OUTPUT);
@@ -134,7 +135,11 @@ float HX711::read()
   {
     //  delayMicroSeconds(1) needed for fast processors?
     digitalWrite(_clockPin, HIGH);
+	if(_fast_processor)
+		delayMicroseconds(1);
     digitalWrite(_clockPin, LOW);
+	if(_fast_processor)
+		delayMicroseconds(1);
     m--;
   }
 
@@ -445,13 +450,15 @@ uint8_t HX711::_shiftIn()
   while (mask > 0)
   {
     digitalWrite(clk, HIGH);
-    delayMicroseconds(1);   //  T2  >= 0.2 us
+		if(_fast_processor)
+			delayMicroseconds(1);
     if (digitalRead(data) == HIGH)
     {
       value |= mask;
     }
     digitalWrite(clk, LOW);
-    delayMicroseconds(1);   //  keep duty cycle ~50%
+		if(_fast_processor)
+			delayMicroseconds(1);
     mask >>= 1;
   }
   return value;

--- a/HX711.h
+++ b/HX711.h
@@ -41,7 +41,7 @@ public:
   ~HX711();
 
   //  fixed gain 128 for now
-  void     begin(uint8_t dataPin, uint8_t clockPin);
+  void     begin(uint8_t dataPin, uint8_t clockPin, bool fastProcessor = false);
 
   void     reset();
 
@@ -164,6 +164,7 @@ private:
 
   void     _insertSort(float * array, uint8_t size);
   uint8_t  _shiftIn();
+	bool _fast_processor = false;
 };
 
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Steps to take for calibration
 
 - **HX711()** constructor.
 - **~HX711()**
-- **void begin(uint8_t dataPin, uint8_t clockPin)** sets a fixed gain 128 for now.
+- **void begin(uint8_t dataPin, uint8_t clockPin, bool fastProcessor)** sets a fixed gain 128 for now.
+The fastProcessor option adds a 1uS delay for each clock half-cycle to keep the time greater than 200nS
 - **void reset()** set internal state to start condition.
 Since 0.3.4 reset also does a power down / up cycle.
 - **bool is_ready()** checks if load cell is ready to read.


### PR DESCRIPTION
Add optional 1uS delays to begin( ), read( ) and _shiftIn( ) to accommodate processors > 500 MHz.

Reduces no_interrupts time for slower processors.